### PR TITLE
Added support for new MeshCentral response type. on `Session.list_devices`

### DIFF
--- a/src/meshctrl/session.py
+++ b/src/meshctrl/session.py
@@ -478,7 +478,6 @@ class Session(object):
         if "result" in res0:
             raise exceptions.ServerError(res0["result"])
         if details:
-            nodes = json.loads(res0["data"])
             try:
                 raw_data = res0["data"]
                 if isinstance(raw_data, str):


### PR DESCRIPTION
After MeshCentral no longer double stringifies. pyLibMeshctrl receive data again! But to fix the type error.

Reference.
https://github.com/Ylianst/MeshCentral/commit/2b4ab2b1226061e62616e6cb2421cd3ea84290ae