### PR TITLE
Increase limit

### DIFF
--- a/src/meshctrl/session.py
+++ b/src/meshctrl/session.py
@@ -144,7 +144,7 @@ class Session(object):
 
 
             options["additional_headers"] = headers
-            async for websocket in websockets.asyncio.client.connect(self.url, proxy=self._proxy, process_exception=util._process_websocket_exception, **options):
+            async for websocket in websockets.asyncio.client.connect(self.url, proxy=self._proxy, process_exception=util._process_websocket_exception, max_size=None, **options):
                 self.alive = True
                 self._socket_open.set()
                 try:


### PR DESCRIPTION
Hello Josiah,

I am so incredibly sorry. Apparently the issues in:
- https://github.com/Ylianst/MeshCentral/issues/7103
- https://github.com/HuFlungDu/pylibmeshctrl/issues/46
- https://github.com/Ylianst/MeshCentral/issues/6905

They were probably all linked to the size limit. Apparently the default size limit is 1MB, which could with such a large amount of data be exceeded easily... for reference: https://websockets.readthedocs.io/en/stable/reference/asyncio/client.html#opening-a-connection

Something to keep an eye on in the future, I set it in session.py to 16 * 1024 * 1024 bytes.

Again Josiah, I'm so sorry for wasting the time.